### PR TITLE
[WIP] Add GTK2

### DIFF
--- a/recipes/gtk2/build.sh
+++ b/recipes/gtk2/build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -x -e
+
+post_install() {
+  # remove libtool la files, assuming all la files are from libtool
+  find "$PREFIX" -name \*.la -exec /bin/rm {} \;
+  # strip binaries
+  find "$PREFIX" -type f -perm -0100 ! -name \*.debug -links 1 -exec sh -c \
+       'if file {} | grep -q " ELF "; then
+          strip --strip-unneeded -R .comment "{}"
+          echo "-> {}"
+        fi' \;
+  echo '-- end of post_install() --'
+}
+
+
+./configure --prefix=$PREFIX \
+            --enable-shared --disable-static \
+            --disable-visibility --disable-introspection \
+            --disable-glibtest --disable-cups --disable-papi \
+            --with-included-immodules
+make -j$CPU_COUNT
+make -j$CPU_COUNT RUN_QUERY_IMMODULES_TEST=false install
+rm -rf $PREFIX/share/gtk-doc
+post_install

--- a/recipes/gtk2/meta.yaml
+++ b/recipes/gtk2/meta.yaml
@@ -52,7 +52,3 @@ about:
   license_file: COPYING
   home: http://www.gtk.org
 
-extra:
-  recipe-url: https://github.com/loopbio/gtk2-feedstock
-  recipe-maintainers:
-    - sdvillal

--- a/recipes/gtk2/meta.yaml
+++ b/recipes/gtk2/meta.yaml
@@ -1,0 +1,58 @@
+# Find our git repo: https://github.com/loopbio/gtk2-feedstock
+
+# Modified from a recipe by Marcin Wojdyr
+
+#
+# Work in progress; the goal would be to have all dependencies
+# (gtk2 is the banana, and client X11 libraries is the gorilla)
+# into conda-forge like recipes.
+# At the moment most dependencies are taken from either conda-forge
+# or from packages by Peter Williams:
+#   https://github.com/pkgw/conda-recipes
+#   https://anaconda.org/pkgw-forge
+# Conda-forge is slowly getting many relevant packages.
+#
+
+{% set major_version = "2.24" %}
+{% set minor_version = "31" %}
+{% set version = major_version + "." +minor_version %}
+
+package:
+  name: gtk2
+  version: {{ version }}
+
+source:
+  fn: gtk+-{{ version }}.tar.xz
+  url: http://ftp.gnome.org/pub/gnome/sources/gtk+/{{ major_version }}/gtk+-{{ version }}.tar.xz
+  sha256: 68c1922732c7efc08df4656a5366dcc3afdc8791513400dac276009b40954658
+
+build:
+  number: 1
+  skip: True  # [not linux]
+  detect_binary_files_with_prefix: True
+  track_features:
+    - gtk2
+
+requirements:
+  build:
+    - glib        # @conda-forge
+    - cairo       # @conda-forge
+    - pango       # @conda-forge
+    - atk         # @pkgw-forge
+    - gdk-pixbuf  # @pkgw-forge
+  run:
+    - glib
+    - cairo
+    - pango
+    - atk
+    - gdk-pixbuf
+
+about:
+  license: LGPL-2
+  license_file: COPYING
+  home: http://www.gtk.org
+
+extra:
+  recipe-url: https://github.com/loopbio/gtk2-feedstock
+  recipe-maintainers:
+    - sdvillal


### PR DESCRIPTION
From discussion at https://github.com/conda-forge/opencv-feedstock/issues/43. Our original recipe is [here](https://github.com/loopbio/gtk2-feedstock).

I wonder if it would make the trick to shape ```build.sh``` after the one you use for GTK3.